### PR TITLE
Refactor `loadNext` method

### DIFF
--- a/__tests__/floodgate.test.js
+++ b/__tests__/floodgate.test.js
@@ -1,26 +1,26 @@
-import rAFPolyfill from './__test_utils__'
-import React from 'react'
-import jest from 'jest'
-import Enzyme, { render, shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-import toJSON from 'enzyme-to-json'
+import rAFPolyfill from "./__test_utils__";
+import React from "react";
+import jest from "jest";
+import Enzyme, { render, shallow, mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import toJSON from "enzyme-to-json";
 
-import Floodgate from '../dist/floodgate.esm'
-import { loopSimulation, theOfficeData } from '../src/helpers'
-import toJson from 'enzyme-to-json'
+import Floodgate from "../dist/floodgate.esm";
+import { loopSimulation, theOfficeData } from "../src/helpers";
+import toJson from "enzyme-to-json";
 
 // configure Enzyme
-Enzyme.configure({ adapter: new Adapter() })
+Enzyme.configure({ adapter: new Adapter() });
 
 // Wrapper instance
-const WrappedFloodgateInstance = fgProps => <WrappedFloodgate {...fgProps} />
+const WrappedFloodgateInstance = fgProps => <WrappedFloodgate {...fgProps} />;
 
 class WrappedFloodgate extends React.Component {
   static defaultProps = {
     floodgateSaveStateOnUnmount: true
-  }
-  constructor () {
-    super()
+  };
+  constructor() {
+    super();
     this.state = {
       showFloodgate: true,
       savedState: {
@@ -28,17 +28,17 @@ class WrappedFloodgate extends React.Component {
         initial: 3,
         increment: 3
       }
-    }
-    this.spliceRandomEntries = this.spliceRandomEntries.bind(this)
-    this.toggleFloodgate = this.toggleFloodgate.bind(this)
-    this.cacheFloodgateState = this.cacheFloodgateState.bind(this)
+    };
+    this.spliceRandomEntries = this.spliceRandomEntries.bind(this);
+    this.toggleFloodgate = this.toggleFloodgate.bind(this);
+    this.cacheFloodgateState = this.cacheFloodgateState.bind(this);
   }
-  spliceRandomEntries () {
-    const data = [...this.state.savedState.data]
-    const randomNumToSplice = Math.ceil(Math.random() * data.length - 1)
-    const randomIndexToSplice = () => Math.floor(Math.random() * data.length)
+  spliceRandomEntries() {
+    const data = [...this.state.savedState.data];
+    const randomNumToSplice = Math.ceil(Math.random() * data.length - 1);
+    const randomIndexToSplice = () => Math.floor(Math.random() * data.length);
     for (let i = 0; i < randomNumToSplice; i++) {
-      data.splice(randomIndexToSplice(), 1)
+      data.splice(randomIndexToSplice(), 1);
     }
     this.setState(prevState => ({
       ...prevState,
@@ -46,31 +46,31 @@ class WrappedFloodgate extends React.Component {
         ...prevState.savedState,
         data
       }
-    }))
-    return data.length
+    }));
+    return data.length;
   }
-  toggleFloodgate () {
+  toggleFloodgate() {
     this.setState(prevState => ({
       ...prevState,
       showFloodgate: !prevState.showFloodgate
-    }))
+    }));
   }
-  cacheFloodgateState ({ currentIndex: initial }) {
+  cacheFloodgateState({ currentIndex: initial }) {
     this.setState(prevState => ({
       ...prevState,
       savedState: {
         ...prevState.savedState,
         initial
       }
-    }))
+    }));
   }
-  render () {
+  render() {
     return (
       <div>
-        <button id='toggleFloodgate' onClick={this.toggleFloodgate}>
+        <button id="toggleFloodgate" onClick={this.toggleFloodgate}>
           Toggle Floodgate
         </button>
-        {this.state.showFloodgate &&
+        {this.state.showFloodgate && (
           <Floodgate
             data={this.state.savedState.data}
             initial={this.state.savedState.initial}
@@ -81,29 +81,32 @@ class WrappedFloodgate extends React.Component {
             {({ items, loadNext, loadAll, reset, loadComplete }) => (
               <main>
                 {items.map(({ name }) => <p key={name}>{name}</p>)}
-                {(!loadComplete &&
+                {(!loadComplete && (
                   <span>
-                    <button id='load' onClick={loadNext}>
+                    <button id="load" onClick={loadNext}>
                       Load More
                     </button>
-                    <button id='loadall' onClick={loadAll}>
+                    <button id="loadall" onClick={loadAll}>
                       Load All
                     </button>
-                    <button id='reset' onClick={reset}>
+                    <button id="reset" onClick={reset}>
                       Reset
                     </button>
-                  </span>) ||
+                  </span>
+                )) || (
                   <p>
                     All items loaded.<br />
-                    <button id='reset' onClick={reset}>
+                    <button id="reset" onClick={reset}>
                       Reset
                     </button>
-                  </p>}
+                  </p>
+                )}
               </main>
             )}
-          </Floodgate>}
+          </Floodgate>
+        )}
       </div>
-    )
+    );
   }
 }
 
@@ -113,220 +116,255 @@ const FloodgateInstance = ({ increment = 3, initial = 3 }) => (
     {({ items, loadNext, loadAll, reset, loadComplete }) => (
       <main>
         {items.map(({ name }) => <p key={name}>{name}</p>)}
-        {(!loadComplete &&
+        {(!loadComplete && (
           <span>
-            <button id='load' onClick={loadNext}>
+            <button id="load" onClick={loadNext}>
               Load More
             </button>
-            <button id='loadall' onClick={loadAll}>
+            <button id="loadall" onClick={loadAll}>
               Load All
             </button>
-            <button id='reset' onClick={reset}>
+            <button id="reset" onClick={reset}>
               Reset
             </button>
-          </span>) ||
+          </span>
+        )) || (
           <p>
             All items loaded.<br />
-            <button id='reset' onClick={reset}>
+            <button id="reset" onClick={reset}>
               Reset
             </button>
-          </p>}
+          </p>
+        )}
       </main>
     )}
   </Floodgate>
-)
+);
 
-describe('Floodgate', () => {
+describe("Floodgate", () => {
   // simple check to make sure Floodgate renders
-  it('1. Should render the Floodgate component', () => {
-    const fgi = render(<FloodgateInstance />)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
+  it("1. Should render the Floodgate component", () => {
+    const fgi = render(<FloodgateInstance />);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
 
   // test instance has correct children
-  it('2. Should render 3 `p` children and 2 `button` child', () => {
-    const fgi = mount(<FloodgateInstance />)
-    expect(fgi.find('p').length).toBe(3)
-    expect(fgi.find('button').length).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
+  it("2. Should render 3 `p` children and 3 `button` child", () => {
+    const fgi = mount(<FloodgateInstance />);
+    expect(fgi.find("p").length).toBe(3);
+    expect(fgi.find("button").length).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
 
   // test instance's children's text values
-  it('3. Should render `p` children that have text matching [Jim Halpert,Pam Halpert,Ed Truck]', () => {
-    const testTextValues = ['Jim Halpert', 'Pam Halpert', 'Ed Truck']
-    const renderedParagraphTextValues = []
-    const fgi = mount(<FloodgateInstance />)
-    fgi.find('p').forEach(p => {
-      renderedParagraphTextValues.push(p.text())
-    })
-    expect(renderedParagraphTextValues).toMatchObject(testTextValues)
-  })
+  it("3. Should render `p` children that have text matching [Jim Halpert,Pam Halpert,Ed Truck]", () => {
+    const testTextValues = ["Jim Halpert", "Pam Halpert", "Ed Truck"];
+    const renderedParagraphTextValues = [];
+    const fgi = mount(<FloodgateInstance />);
+    fgi.find("p").forEach(p => {
+      renderedParagraphTextValues.push(p.text());
+    });
+    expect(renderedParagraphTextValues).toMatchObject(testTextValues);
+  });
 
   // test instance renders non-default lengths of initial
-  it('4. Should render with 4 `p` children', () => {
-    const fgi = mount(<FloodgateInstance initial={4} />)
-    expect(fgi.find('p').length).toBe(4)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
+  it("4. Should render with 4 `p` children", () => {
+    const fgi = mount(<FloodgateInstance initial={4} />);
+    expect(fgi.find("p").length).toBe(4);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
 
   // test instance loads new items
-  it('5. Should render with 3 `p` children and load 3 `p` children `onClick()`', () => {
-    const fgi = mount(<FloodgateInstance />)
-    expect(fgi.find('p').length).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
+  it("5. Should render with 3 `p` children and load 3 `p` children `onClick()`", () => {
+    const fgi = mount(<FloodgateInstance />);
+    expect(fgi.find("p").length).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
 
     // simulate click
-    fgi.find('button#load').simulate('click')
-    expect(fgi.find('p').length).toBe(6)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
+    fgi.find("button#load").simulate("click");
+    expect(fgi.find("p").length).toBe(6);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
   // test instance loads different lengths of increment
-  it('6. Should render with 2 `p` children and load 1 `p` children `onClick()`', () => {
-    const fgi = mount(<FloodgateInstance initial={2} increment={1} />)
-    const loadButton = fgi.find('button#load')
-    const p = (prop = false) => (prop ? fgi.find('p')[prop] : fgi.find('p'))
-    expect(p('length')).toBe(2)
-    expect(toJSON(fgi)).toMatchSnapshot()
+  it("6. Should render with 2 `p` children and load 1 `p` children `onClick()`", () => {
+    const fgi = mount(<FloodgateInstance initial={2} increment={1} />);
+    const loadButton = fgi.find("button#load");
+    const p = (prop = false) => (prop ? fgi.find("p")[prop] : fgi.find("p"));
+    expect(p("length")).toBe(2);
+    expect(toJSON(fgi)).toMatchSnapshot();
 
     // simulate click
-    loadButton.simulate('click')
-    expect(p('length')).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
+    loadButton.simulate("click");
+    expect(p("length")).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
 
-    loopSimulation(2, () => loadButton.simulate('click'))
-    expect(p('length')).toBe(5)
-    expect(fgi.find('button').length).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
+    loopSimulation(2, () => loadButton.simulate("click"));
+    expect(p("length")).toBe(5);
+    expect(fgi.find("button").length).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
 
-    loopSimulation(3, () => loadButton.simulate('click'))
-    expect(p('length')).toBe(8)
-    expect(p().last().text()).toMatch(theOfficeData[7].name)
-    expect(fgi.find('button').length).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
-  it('7. Should render with 2 `p` children, load 1 `p` child, and reset state to original load', () => {
-    const fgi = mount(<FloodgateInstance initial={2} increment={1} />)
-    const loadButton = fgi.find('button#load')
-    const resetButton = fgi.find('button#reset')
-    const p = (prop = false) => (prop ? fgi.find('p')[prop] : fgi.find('p'))
-    expect(p('length')).toBe(2)
-    expect(p().first().text()).toMatch('Jim Halpert')
-    expect(p().last().text()).toMatch('Pam Halpert')
-    expect(toJSON(fgi)).toMatchSnapshot()
+    loopSimulation(3, () => loadButton.simulate("click"));
+    expect(p("length")).toBe(8);
+    expect(
+      p()
+        .last()
+        .text()
+    ).toMatch(theOfficeData[7].name);
+    expect(fgi.find("button").length).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
+  it("7. Should render with 2 `p` children, load 1 `p` child, and reset state to original load", () => {
+    const fgi = mount(<FloodgateInstance initial={2} increment={1} />);
+    const loadButton = fgi.find("button#load");
+    const resetButton = fgi.find("button#reset");
+    const p = (prop = false) => (prop ? fgi.find("p")[prop] : fgi.find("p"));
+    expect(p("length")).toBe(2);
+    expect(
+      p()
+        .first()
+        .text()
+    ).toMatch("Jim Halpert");
+    expect(
+      p()
+        .last()
+        .text()
+    ).toMatch("Pam Halpert");
+    expect(toJSON(fgi)).toMatchSnapshot();
 
-    loadButton.simulate('click')
-    expect(p('length')).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
+    loadButton.simulate("click");
+    expect(p("length")).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
 
-    resetButton.simulate('click')
-    expect(p('length')).toBe(2)
-    expect(p().first().text()).toMatch('Jim Halpert')
-    expect(p().last().text()).toMatch('Pam Halpert')
-    expect(fgi.find('button').length).toBe(3)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
+    resetButton.simulate("click");
+    expect(p("length")).toBe(2);
+    expect(
+      p()
+        .first()
+        .text()
+    ).toMatch("Jim Halpert");
+    expect(
+      p()
+        .last()
+        .text()
+    ).toMatch("Pam Halpert");
+    expect(fgi.find("button").length).toBe(3);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
 
-  it('8. Should render 1 `p` child, click to load all then reset', () => {
-    const fgi = mount(<FloodgateInstance initial={1} increment={2} />)
-    const loadButton = fgi.find('button#load')
-    const loadAllButton = fgi.find('button#loadall')
-    const resetButton = fgi.find('button#reset')
-    const p = (prop = false) => (prop ? fgi.find('p')[prop] : fgi.find('p'))
-    expect(p('length')).toBe(1)
+  it("8. Should render 1 `p` child, click to load all then reset", () => {
+    const fgi = mount(<FloodgateInstance initial={1} increment={2} />);
+    const loadButton = () => fgi.find("button#load");
+    const loadAllButton = () => fgi.find("button#loadall");
+    const resetButton = () => fgi.find("button#reset");
+    const p = (prop = false) => (prop ? fgi.find("p")[prop] : fgi.find("p"));
+    expect(p("length")).toBe(1);
 
-    loadAllButton.simulate('click')
-    expect(p('length')).toBe(theOfficeData.length + 1)
-    expect(p().first().text()).toMatch('Jim Halpert')
-    expect(p().at(theOfficeData.length - 1).text()).toMatch('Angela Schrute')
-    expect(toJSON(fgi)).toMatchSnapshot()
+    loadAllButton().simulate("click");
+    expect(p("length")).toBe(theOfficeData.length + 1);
+    expect(
+      p()
+        .first()
+        .text()
+    ).toMatch("Jim Halpert");
+    expect(
+      p()
+        .at(theOfficeData.length - 1)
+        .text()
+    ).toMatch("Angela Schrute");
+    expect(loadButton()).toHaveLength(0);
+    expect(loadAllButton()).toHaveLength(0);
+    expect(resetButton()).toHaveLength(1);
+    expect(fgi.find(Floodgate).instance().state.allItemsRendered).toBe(true);
 
-    resetButton.simulate('click')
-    expect(p('length')).toBe(1)
-    expect(toJSON(fgi)).toMatchSnapshot()
-  })
-})
+    expect(toJSON(fgi)).toMatchSnapshot();
 
-describe('Wrapped Floodgate for saveState testing', () => {
-  it('1. Should render a wrapped Floodgate instance', () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />)
-    expect(toJSON(wfgi)).toMatchSnapshot()
-  })
-  it('2. Should load 3 items, and save the currentIndex to the WrappedFloodgate state on cWU', () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />)
-    const fgi = wfgi.find(Floodgate).instance()
-    const loadBtn = wfgi.find('button#load')
-    const toggleBtn = wfgi.find('button#toggleFloodgate')
+    resetButton().simulate("click");
+    expect(p("length")).toBe(1);
+    expect(toJSON(fgi)).toMatchSnapshot();
+  });
+});
 
-    expect(fgi.state.currentIndex).toEqual(3)
-    expect(wfgi.find('p')).toHaveLength(3)
+describe("Wrapped Floodgate for saveState testing", () => {
+  it("1. Should render a wrapped Floodgate instance", () => {
+    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    expect(toJSON(wfgi)).toMatchSnapshot();
+  });
+  it("2. Should load 3 items, and save the currentIndex to the WrappedFloodgate state on cWU", () => {
+    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const fgi = wfgi.find(Floodgate).instance();
+    const loadBtn = wfgi.find("button#load");
+    const toggleBtn = wfgi.find("button#toggleFloodgate");
 
-    loadBtn.simulate('click')
+    expect(fgi.state.currentIndex).toEqual(3);
+    expect(wfgi.find("p")).toHaveLength(3);
 
-    expect(wfgi.find('p')).toHaveLength(6)
-    expect(fgi.state.currentIndex).toEqual(6)
+    loadBtn.simulate("click");
 
-    toggleBtn.simulate('click')
-    expect(wfgi.find('p')).toHaveLength(0)
-    expect(wfgi.state().showFloodgate).toBe(false)
-    expect(wfgi.state('savedState')).toMatchObject({
+    expect(wfgi.find("p")).toHaveLength(6);
+    expect(fgi.state.currentIndex).toEqual(6);
+
+    toggleBtn.simulate("click");
+    expect(wfgi.find("p")).toHaveLength(0);
+    expect(wfgi.state().showFloodgate).toBe(false);
+    expect(wfgi.state("savedState")).toMatchObject({
       data: theOfficeData,
       initial: 6,
       increment: 3
-    })
-  })
-  it('2. Should load 3 items, click to load 3 more items, toggle Floodgate, and persist Floodgate state through mounting/re-mounting', () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />)
-    const getFgi = () => wfgi.find(Floodgate).instance()
-    const loadBtn = wfgi.find('button#load')
-    const toggleBtn = wfgi.find('button#toggleFloodgate')
+    });
+  });
+  it("2. Should load 3 items, click to load 3 more items, toggle Floodgate, and persist Floodgate state through mounting/re-mounting", () => {
+    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const getFgi = () => wfgi.find(Floodgate).instance();
+    const loadBtn = wfgi.find("button#load");
+    const toggleBtn = wfgi.find("button#toggleFloodgate");
 
-    expect(getFgi().state.currentIndex).toEqual(3)
-    expect(wfgi.find('p')).toHaveLength(3)
+    expect(getFgi().state.currentIndex).toEqual(3);
+    expect(wfgi.find("p")).toHaveLength(3);
 
-    loadBtn.simulate('click')
+    loadBtn.simulate("click");
 
-    expect(wfgi.find('p')).toHaveLength(6)
-    expect(getFgi().state.currentIndex).toEqual(6)
+    expect(wfgi.find("p")).toHaveLength(6);
+    expect(getFgi().state.currentIndex).toEqual(6);
 
-    toggleBtn.simulate('click')
+    toggleBtn.simulate("click");
     // wfgi.setState({ showFloodgate: false })
 
-    expect(wfgi.find('p')).toHaveLength(0)
-    expect(wfgi.state().showFloodgate).toBe(false)
-    expect(wfgi.state('savedState')).toMatchObject({
+    expect(wfgi.find("p")).toHaveLength(0);
+    expect(wfgi.state().showFloodgate).toBe(false);
+    expect(wfgi.state("savedState")).toMatchObject({
       data: theOfficeData,
       initial: 6,
       increment: 3
-    })
+    });
 
-    toggleBtn.simulate('click')
-    expect(wfgi.state().showFloodgate).toBe(true)
-    expect(getFgi().state.currentIndex).toBe(6)
-  })
-  it('3. Should load 3 items, toggle Floodgate, randomly splice data entries, then persist Floodgate index state through mounting/re-mounting', () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />)
-    const getFgi = () => wfgi.find(Floodgate).instance()
-    const toggleBtn = wfgi.find('button#toggleFloodgate')
+    toggleBtn.simulate("click");
+    expect(wfgi.state().showFloodgate).toBe(true);
+    expect(getFgi().state.currentIndex).toBe(6);
+  });
+  it("3. Should load 3 items, toggle Floodgate, randomly splice data entries, then persist Floodgate index state through mounting/re-mounting", () => {
+    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const getFgi = () => wfgi.find(Floodgate).instance();
+    const toggleBtn = wfgi.find("button#toggleFloodgate");
 
-    expect(getFgi().state.currentIndex).toEqual(3)
-    expect(wfgi.find('p')).toHaveLength(3)
+    expect(getFgi().state.currentIndex).toEqual(3);
+    expect(wfgi.find("p")).toHaveLength(3);
 
-    toggleBtn.simulate('click')
+    toggleBtn.simulate("click");
 
-    expect(wfgi.find('p')).toHaveLength(0)
-    expect(wfgi.state().showFloodgate).toBe(false)
-    expect(wfgi.state('savedState')).toMatchObject({
+    expect(wfgi.find("p")).toHaveLength(0);
+    expect(wfgi.state().showFloodgate).toBe(false);
+    expect(wfgi.state("savedState")).toMatchObject({
       data: theOfficeData,
       initial: 3,
       increment: 3
-    })
+    });
 
-    wfgi.instance().spliceRandomEntries()
+    wfgi.instance().spliceRandomEntries();
 
-    toggleBtn.simulate('click')
-    expect(wfgi.state().showFloodgate).toBe(true)
+    toggleBtn.simulate("click");
+    expect(wfgi.state().showFloodgate).toBe(true);
     expect(getFgi().state.renderedItems).toMatchObject(
       wfgi.state().savedState.data.slice(0, 3)
-    )
-  })
-})
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-floodgate",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "Configurable and flexible React component for incrementally displaying data.",
 	"main": "dist/floodgate.cjs.js",
 	"jsnext:main": "dist/floodgate.esm.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,19 +63,19 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
       callback,
       suppressWarning
     }: { callback?: Function, suppressWarning: boolean } = {
-        suppressWarning: false
-      }
+      suppressWarning: false
+    }
   ): void {
-    (!this.state.allItemsRendered &&
-      this.setState(prevState => {
-        return {
-          renderedItems: this.data,
-          allItemsRendered: true
-        };
-      }, () => callback && callback(this.state))) ||
-      (this.state.allItemsRendered &&
+    !this.state.allItemsRendered
+      ? this.setState(prevState => {
+          return {
+            renderedItems: this.data,
+            allItemsRendered: true
+          };
+        }, () => callback && callback(this.state))
+      : this.state.allItemsRendered &&
         !suppressWarning &&
-        console.warn("Floodgate: All items are rendered"));
+        console.warn("Floodgate: All items are rendered");
   }
   loadNext({ callback }: { callback?: Function } = {}): void {
     !this.state.allItemsRendered &&

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,14 +78,14 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
         console.warn("Floodgate: All items are rendered");
   }
   loadNext({ callback }: { callback?: Function } = {}): void {
-    !this.state.allItemsRendered &&
+    if (!this.state.allItemsRendered) {
+      // Get next iteratable
+      const { value } = this.queue.next();
+      // Check if array value exists and has at least one element
+      const valueIsAvailable: boolean = value && value.length;
+
       this.setState(prevState => {
-        // Get next iteratable
-        const { value, done } = this.queue.next();
-        // Check if array value exists and has at least one element
-        const valueIsAvailable: boolean =
-          value !== null && value !== undefined && value.length > 0;
-        // Combine new items with rendered items from state
+        // Apply new data if available
         const newRenderedData = [
           ...prevState.renderedItems,
           ...(valueIsAvailable ? value : [])
@@ -93,7 +93,6 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
         // Check if all data items have been rendered
         const dataLengthMatches: boolean =
           newRenderedData.length === this.data.length;
-
         return {
           renderedItems: newRenderedData,
           currentIndex: newRenderedData.length,
@@ -103,6 +102,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
               : false
         };
       }, () => callback && callback(this.state));
+    }
   }
   saveState() {
     const { renderedItems, currentIndex, allItemsRendered } = this.state;


### PR DESCRIPTION
### What:
Refactored `loadNext`.

### Why:
Make logic more readable, attempt to reduce complexity.

### How:
- Change top-level comparison expression into if statement
- Moved business logic out of `setState` when possible

### Reference:

Closes #26 