### PR TITLE
Add Travis CI to Floodgate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ node_modules/
 package-lock.json
 demo.js 
 .rpt2_cache/ 
-dist
+dist 
+.travis.yml.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - 8.9
+sudo: enabled
+branches:
+  except:
+    - /documentation\/.+/
+install:
+  - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ branches:
     - /documentation\/.+/
 install:
   - yarn
+script:
+  - yarn run build


### PR DESCRIPTION
### What:
Adds configuration for Travis CI integration to Floodgate project; Travis CI has been enabled for this repository.

### Why:
Run tests on branch commits and PRs for consistent testing experience.

### How:
- Added `.travis.yml`
- Enabled repository in Travis CI app
- Hooked up Travis CI in Github Marketplace

### Reference:

Closes #8 