### PR TITLE
Bugfix: Add missing event callback proptypes

### DIFF
--- a/__tests__/floodgate.test.js
+++ b/__tests__/floodgate.test.js
@@ -394,6 +394,22 @@ describe("Floodgate", () => {
     loadButton().simulate("click");
     expect(mockedLoadNextCallback.mock.calls.length).toEqual(0);
   });
+  it("14. Should give propType error when non-function value passed to event callback props", () => {
+    const fgi = mount(
+      <FloodgateInstance
+        onLoadNext={{ shouldError: true }}
+        onLoadComplete={{ shouldError: true }}
+        onReset={{ shouldError: true }}
+      />
+    );
+    const loadButton = fgi.find("button#load");
+    const loadAllButton = () => fgi.find("button#loadall");
+    const resetButton = () => fgi.find("button#reset");
+
+    expect(() => loadButton.simulate("click")).toThrowError();
+    expect(() => loadAllButton.simulate("click")).toThrowError();
+    expect(() => resetButton.simulate("click")).toThrowError();
+  });
 });
 
 describe("Wrapped Floodgate for saveState testing", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-floodgate",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "Configurable and flexible React component for incrementally displaying data.",
 	"keywords": [
 		"react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,10 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     initial: PropTypes.number,
     increment: PropTypes.number,
     saveStateOnUnmount: PropTypes.bool,
-    exportState: PropTypes.func
+    exportState: PropTypes.func,
+    onLoadNext: PropTypes.func,
+    onLoadComplete: PropTypes.func,
+    onReset: PropTypes.func
   };
   static defaultProps = {
     initial: 5,


### PR DESCRIPTION
### What:
Added propTypes for event prop callbacks

### Why:
Keeps experience consistent when providing bad values to props.

### How:
Added event prop callbacks to `static propTypes`

### Reference: 
Closes #32