### PR TITLE
Bugfix: reset allows custom initial value, loadAll updates currentIndex

### DIFF
--- a/__tests__/floodgate.test.js
+++ b/__tests__/floodgate.test.js
@@ -55,15 +55,22 @@ class WrappedFloodgate extends React.Component {
     }));
   }
   cacheFloodgateState({ currentIndex: initial }) {
-    this.setState(prevState => ({
-      ...prevState,
-      savedState: {
-        ...prevState.savedState,
-        initial
-      }
-    }));
+    this.setState(prevState => {
+      return {
+        ...prevState,
+        savedState: {
+          ...prevState.savedState,
+          initial
+        }
+      };
+    });
   }
   render() {
+    const ResetButton = ({ reset }) => (
+      <button id="reset" onClick={() => reset({ initial: 3 })}>
+        Reset
+      </button>
+    );
     return (
       <div>
         <button id="toggleFloodgate" onClick={this.toggleFloodgate}>
@@ -79,7 +86,9 @@ class WrappedFloodgate extends React.Component {
           >
             {({ items, loadNext, loadAll, reset, loadComplete }) => (
               <main>
-                {items.map(({ name }) => <p key={name}>{name}</p>)}
+                {items.map(({ name }) => (
+                  <p key={name}>{name}</p>
+                ))}
                 {(!loadComplete && (
                   <span>
                     <button id="load" onClick={loadNext}>
@@ -88,17 +97,14 @@ class WrappedFloodgate extends React.Component {
                     <button id="loadall" onClick={loadAll}>
                       Load All
                     </button>
-                    <button id="reset" onClick={reset}>
-                      Reset
-                    </button>
+                    <ResetButton reset={reset} />
                   </span>
                 )) || (
-                  <p>
-                    All items loaded.<br />
-                    <button id="reset" onClick={reset}>
-                      Reset
-                    </button>
-                  </p>
+                  <div>
+                    All items loaded.
+                    <br />
+                    <ResetButton reset={reset} />
+                  </div>
                 )}
               </main>
             )}
@@ -153,7 +159,11 @@ class ControlledFloodgate extends React.Component {
         <Floodgate data={this.state.data} initial={3} increment={1}>
           {({ items, loadNext, loadComplete }) => (
             <div>
-              <ul>{items.map(n => <li key={n.toString()}>{n}</li>)}</ul>
+              <ul>
+                {items.map(n => (
+                  <li key={n.toString()}>{n}</li>
+                ))}
+              </ul>
               <button id="loadNext" onClick={loadNext} disabled={loadComplete}>
                 Load More
               </button>
@@ -204,7 +214,8 @@ const FloodgateInstance = ({
           </span>
         )) || (
           <p>
-            All items loaded.<br />
+            All items loaded.
+            <br />
             <button id="reset" onClick={reset}>
               Reset
             </button>
@@ -342,13 +353,16 @@ describe("Floodgate", () => {
     ).toMatch("Jim Halpert");
     expect(
       p()
-        .at(theOfficeData.length - 1)
+        .at(fgi.find(Floodgate).instance().props.data.length - 1)
         .text()
     ).toMatch("Angela Schrute");
     expect(loadButton()).toHaveLength(0);
     expect(loadAllButton()).toHaveLength(0);
     expect(resetButton()).toHaveLength(1);
     expect(fgi.find(Floodgate).instance().state.allItemsRendered).toBe(true);
+    expect(fgi.find(Floodgate).instance().state.currentIndex).toBe(
+      fgi.find(Floodgate).instance().props.data.length
+    );
 
     expect(toJSON(fgi)).toMatchSnapshot();
 
@@ -557,6 +571,39 @@ describe("Wrapped Floodgate for saveState testing", () => {
     expect(getFgi().state.renderedItems).toMatchObject(
       wfgi.state().savedState.data.slice(0, 3)
     );
+  });
+  it("4. Should load 3 items, click to load all items, toggle Floodgate, reset should update state based on newInitial argument prop", () => {
+    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const getFgi = () => wfgi.find(Floodgate).instance();
+    const getResetBtn = () => wfgi.find("button#reset");
+    const loadAllBtn = wfgi.find("button#loadall");
+    const toggleBtn = wfgi.find("button#toggleFloodgate");
+
+    expect(getFgi().state.currentIndex).toEqual(3);
+    expect(wfgi.find("p")).toHaveLength(3);
+
+    loadAllBtn.simulate("click");
+
+    expect(wfgi.find("p")).toHaveLength(getFgi().props.data.length);
+    expect(getFgi().state.allItemsRendered).toBe(true);
+
+    toggleBtn.simulate("click");
+    wfgi.setState({ showFloodgate: false });
+
+    expect(wfgi.find("p")).toHaveLength(0);
+    expect(wfgi.state().showFloodgate).toBe(false);
+    expect(wfgi.state("savedState")).toMatchObject({
+      data: theOfficeData,
+      initial: theOfficeData.length,
+      increment: 3
+    });
+
+    toggleBtn.simulate("click");
+    expect(wfgi.state().showFloodgate).toBe(true);
+
+    getResetBtn().simulate("click");
+    expect(getFgi().state.currentIndex).toBe(3);
+    expect(wfgi.find("p")).toHaveLength(3);
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,19 +53,19 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     this.reset = this.reset.bind(this);
     this.saveState = this.saveState.bind(this);
     this[initGeneratorSymbol](
-      this.state.items,
+      this.props.data,
       this.props.increment,
       this.props.initial
     );
   }
-  [initGeneratorSymbol](items, increment, initial) {
-    this.queue = generator(items, increment, initial);
+  [initGeneratorSymbol](data, increment, initial) {
+    this.queue = generator(data, increment, initial);
   }
   componentDidMount(): void {
     this.loadNext({ silent: true });
   }
   componentDidUpdate(prevProps, prevState): void {
-    const { data, increment, initial } = this.props;
+    const { data, increment } = this.props;
     if (this.props !== prevProps) {
       this[initGeneratorSymbol](
         data.slice(prevState.currentIndex, data.length),
@@ -83,12 +83,24 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     // Prevent unwanted cacheing by setting saveStateOnUnmount to false
     this.props.saveStateOnUnmount && this.saveState();
   }
-  reset({ callback }: { callback?: Function } = {}): void {
-    this.queue = generator(this.data, this.props.increment, this.props.initial);
+  reset({
+    initial,
+    callback
+  }: { initial?: number, callback?: Function } = {}): void {
+    this[initGeneratorSymbol](
+      this.data,
+      this.props.increment,
+      typeof initial !== "undefined" ? initial : this.props.initial
+    );
+
     this.setState(
       prevState => ({
         renderedItems: [],
-        allItemsRendered: false
+        allItemsRendered: false,
+        prevProps: {
+          ...prevState.prevProps,
+          initial: typeof initial !== "undefined" ? initial : this.props.initial
+        }
       }),
       () => {
         this.loadNext({ silent: true, callback });
@@ -109,6 +121,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
           prevState => {
             return {
               renderedItems: this.data,
+              currentIndex: this.data.length,
               allItemsRendered: true
             };
           },

--- a/stories/index.js
+++ b/stories/index.js
@@ -36,7 +36,9 @@ storiesOf("Floodgate/simple", module)
       <Floodgate data={generateFilledArray(9)} initial={2} increment={2}>
         {({ items, loadNext, loadComplete }) => (
           <article>
-            {items.map(n => <p key={n}>{n}</p>)}
+            {items.map(n => (
+              <p key={n}>{n}</p>
+            ))}
             {(!loadComplete && (
               <p>
                 <button onClick={loadNext}>Load More</button>
@@ -53,7 +55,9 @@ storiesOf("Floodgate/simple", module)
       <Floodgate data={generateFilledArray(9)} increment={3} initial={3}>
         {({ items, loadNext, loadComplete }) => (
           <article>
-            {items.map(n => <p key={n}>{n}</p>)}
+            {items.map(n => (
+              <p key={n}>{n}</p>
+            ))}
             {(!loadComplete && (
               <p>
                 <button onClick={loadNext}>Load More</button>
@@ -70,7 +74,9 @@ storiesOf("Floodgate/simple", module)
       <Floodgate data={generateFilledArray(9)} increment={3} initial={4}>
         {({ items, loadNext, loadComplete }) => (
           <article>
-            {items.map(n => <p key={n}>{n}</p>)}
+            {items.map(n => (
+              <p key={n}>{n}</p>
+            ))}
             {(!loadComplete && (
               <p>
                 <button onClick={loadNext}>Load More</button>
@@ -85,7 +91,9 @@ storiesOf("Floodgate/simple", module)
     <Floodgate data={generateFilledArray(9)} initial={9}>
       {({ items, loadNext, loadComplete }) => (
         <article>
-          {items.map(n => <p key={n}>{n}</p>)}
+          {items.map(n => (
+            <p key={n}>{n}</p>
+          ))}
           {(!loadComplete && (
             <p>
               <button onClick={loadNext}>Load More</button>
@@ -99,7 +107,9 @@ storiesOf("Floodgate/simple", module)
     <Floodgate data={generateFilledArray(25)}>
       {({ items, loadNext, loadComplete, reset }) => (
         <article>
-          {items.map(n => <p key={n}>{n}</p>)}
+          {items.map(n => (
+            <p key={n}>{n}</p>
+          ))}
           {(!loadComplete && (
             <p>
               <button onClick={loadNext}>Load More</button>
@@ -107,7 +117,8 @@ storiesOf("Floodgate/simple", module)
             </p>
           )) || (
             <p>
-              All loaded.<br />
+              All loaded.
+              <br />
               <button onClick={reset}>Reset</button>
             </p>
           )}
@@ -138,26 +149,30 @@ storiesOf("Floodgate/simple", module)
                       });
                       window.location = "#last";
                     }
-                  })}
+                  })
+                }
               >
                 Load More
               </button>
               <button
                 onClick={e =>
-                  reset({ callback: state => console.log("RESET", { state }) })}
+                  reset({ callback: state => console.log("RESET", { state }) })
+                }
               >
                 Reset
               </button>
             </p>
           )) || (
             <p>
-              All loaded.<br />
+              All loaded.
+              <br />
               <button
                 onClick={e =>
                   reset({
                     callback: state =>
                       console.log("RESET AFTER ALL LOADED", { state })
-                  })}
+                  })
+                }
               >
                 Reset
               </button>
@@ -192,7 +207,8 @@ storiesOf("Floodgate/simple", module)
                         });
                         window.location = "#last";
                       }
-                    })}
+                    })
+                  }
                 >
                   Load More
                 </button>
@@ -201,7 +217,8 @@ storiesOf("Floodgate/simple", module)
                     loadAll({
                       callback: state => console.log("LOAD ALL", { state }),
                       suppressWarning: false
-                    })}
+                    })
+                  }
                 >
                   Load All
                 </button>
@@ -209,20 +226,23 @@ storiesOf("Floodgate/simple", module)
                   onClick={e =>
                     reset({
                       callback: state => console.log("RESET", { state })
-                    })}
+                    })
+                  }
                 >
                   Reset
                 </button>
               </p>
             )) || (
               <p>
-                All loaded.<br />
+                All loaded.
+                <br />
                 <button
                   onClick={e =>
                     reset({
                       callback: state =>
                         console.log("RESET AFTER ALL LOADED", { state })
-                    })}
+                    })
+                  }
                 >
                   Reset
                 </button>
@@ -281,7 +301,11 @@ storiesOf("Floodgate/simple", module)
             <Floodgate data={this.state.data} initial={3} increment={1}>
               {({ items, loadNext, loadComplete }) => (
                 <div>
-                  <ul>{items.map(n => <li>{n}</li>)}</ul>
+                  <ul>
+                    {items.map(n => (
+                      <li>{n}</li>
+                    ))}
+                  </ul>
                   <button onClick={loadNext} disabled={loadComplete}>
                     Load More
                   </button>
@@ -318,16 +342,24 @@ storiesOf("Floodgate/simple", module)
                   stashState("savedFloodgateState", {
                     ...state,
                     initial: state.currentIndex
-                  })}
+                  })
+                }
               >
-                {({ items, loadNext, loadComplete, reset }) => (
+                {({ items, loadNext, loadAll, loadComplete, reset }) => (
                   <article>
-                    {items.map(n => <p key={n.toString()}>{n}</p>)}
+                    {items.map(n => (
+                      <p key={n.toString()}>{n}</p>
+                    ))}
                     <br />
                     {!loadComplete ? (
-                      <button onClick={loadNext}>load next</button>
+                      <React.Fragment>
+                        <button onClick={loadNext}>load next</button>
+                        <button onClick={loadAll}>load all</button>
+                      </React.Fragment>
                     ) : (
-                      <button onClick={reset}>reset</button>
+                      <button onClick={() => reset({ initial: 3 })}>
+                        reset
+                      </button>
                     )}
                   </article>
                 )}
@@ -359,16 +391,21 @@ storiesOf("Floodgate/simple", module)
                   stashState("savedFloodgateState", {
                     ...state,
                     initial: state.currentIndex
-                  })}
+                  })
+                }
               >
                 {({ items, loadNext, loadComplete, reset }) => (
                   <article>
-                    {items.map(n => <p key={n.toString()}>{n}</p>)}
+                    {items.map(n => (
+                      <p key={n.toString()}>{n}</p>
+                    ))}
                     <br />
                     {!loadComplete ? (
                       <button onClick={loadNext}>load next</button>
                     ) : (
-                      <button onClick={reset}>reset</button>
+                      <button onClick={() => reset({ initial: 3 })}>
+                        reset
+                      </button>
                     )}
                   </article>
                 )}


### PR DESCRIPTION
### What:
1. Add support for `Floodgate#reset` to explicitly pass new `initial` value to new `Floodgate#queue` generator
2. Fix `Floodgate#loadAll` not updating `Floodgate#state.currentIndex`

### Why:
1. Floodgate's state locks up if its props are controlled by a parent, `exportState` is saved by that parent, and Floodgate is toggled between mounted instances in a "`loadComplete === true`" state
    - When mounting is toggled, `exportState` could save the `currentIndex` value which could then be mapped to the `initial` prop when re-mounted
    - This creates a situation where the `initial` value is equal to the length of the `data` prop's value, making the `reset` method useless
2. Mostly for testing purposes, but also to ensure a consistent experience between the `load` methods

### How:
1. Adding the `initial` property to the `Floodgate#reset` method's parameter
    - Used in the initialization of a new Generator
    - When not specified, defaults to `Floodgate#props.initial`
2. Setting `Floodgate#state.currentIndex` to the length of `Floodgate#data`

### Reference: 

Closes #40 
Closes #41 