### PR TITLE
Update API to use new exportState Naming Conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const BasicExample = props => (
     data={[4, 8, 15, 16, 23, 42]}
     initial={3}
     increment={1}
-    saveStateOnUnMount={false}
+    exportStateOnUnMount={false}
     onLoadNext={(stateAtLoadNext) => console.log(stateAtLoadNext)}
     onLoadAll={(stateAtLoadAll) => console.log(stateAtLoadAll)}
     onReset={(stateAtReset) => console.log(stateAtReset)}>
@@ -70,7 +70,7 @@ Uncontrolled Floodgate components are entirely static, and their state will be c
 
 ### Controlled Floodgate
 
-The following is a basic example of a controlled Floodgate implementation; this component has a location to save Floodgate state, and uses those values as Floodgate's props. In order to make sure this component does save Floodgate's state, the `exportState` prop will have to have a function passed to it that saves desired Floodgate state properties to the controlling component's state.
+The following is a basic example of a controlled Floodgate implementation; this component has a location to save Floodgate state, and uses those values as Floodgate's props. In order to make sure this component does save Floodgate's state, the `onExportState` prop will have to have a function passed to it that saves desired Floodgate state properties to the controlling component's state.
 
 ```javascript
 class FloodgateController extends React.Component {
@@ -99,8 +99,8 @@ class FloodgateController extends React.Component {
           data={this.state.FGState.data} 
           increment={this.state.FGState.increment} 
           initial={this.state.FGState.initial}
-          saveStateOnUnmount={true}
-          exportState={newFGState => this.setState(prevState => ({
+          exportStateOnUnmount={true}
+          onExportState={newFGState => this.setState(prevState => ({
             FGState: {
               ...prevState.FGState,
               ...newFGState,
@@ -168,16 +168,16 @@ const ControlledFGInstance = <FloodgateController<any> data={[4, 'eight', 15, 's
 
 ### `Floodgate` props
 
-| name                 | type        | default      | description                                                                               |
-|----------------------|-------------|--------------|-------------------------------------------------------------------------------------------|
-| `data`               | Array\<any> | `null`       | The array of items to be processed by `Floodgate`|                                        |
-| `initial`            | number      | `5`          | How many items are initially available in the render function|                            |
-| `increment`          | number      | `5`          | How many items are added when calling `loadNext`|                                         |
-| `saveStateOnUnmount` | boolean     | *(optional)* | Toggle if `exportState` will be called during `componentWillUnmount`                      |
-| `exportState`        | Function    | *(optional)* | Function to pass up Floodgate's internal state when `componentWillUnmount` fires          |
-| `onLoadNext`         | Function    | *(optional)* | Callback function to run after `loadNext`; runs after inline `callback` argument prop     |
-| `onLoadComplete`     | Function    | *(optional)* | Callback function to run after `loadComplete`; runs after inline `callback` argument prop |
-| `onReset`            | Function    | *(optional)* | Callback function to run after `reset`; runs after inline `callback` argument prop        |
+| name                   | type        | default      | description                                                                                                 |
+|------------------------|-------------|--------------|-------------------------------------------------------------------------------------------------------------|
+| `data`                 | Array\<any> | `null`       | The array of items to be processed by `Floodgate`|                                                          |
+| `initial`              | number      | `5`          | How many items are initially available in the render function|                                              |
+| `increment`            | number      | `5`          | How many items are added when calling `loadNext`|                                                           |
+| `exportStateOnUnmount` | boolean     | *(optional)* | Toggle if `exportState` will be called during `componentWillUnmount`                                        |
+| `onExportState`        | Function    | *(optional)* | Function to pass up Floodgate's internal state when `componentWillUnmount` fires or `exportState` is called |
+| `onLoadNext`           | Function    | *(optional)* | Callback function to run after `loadNext`; runs after inline `callback` argument prop                       |
+| `onLoadComplete`       | Function    | *(optional)* | Callback function to run after `loadComplete`; runs after inline `callback` argument prop                   |
+| `onReset`              | Function    | *(optional)* | Callback function to run after `reset`; runs after inline `callback` argument prop                          |
 
 #### `data`
 
@@ -207,17 +207,17 @@ The length of the first set of items that will be rendered from Floodgate. <!-- 
 
 The length of subsequent sets of items when calling `loadNext`. <!-- If `increment` is negative or zero, this will default to the default value of 5 -->
 
-#### `saveStateOnUnmount`
+#### `exportStateOnUnmount`
 
 *Type:* `boolean = false`
 
-Flag to configure the calling of `props.exportState` when Floodgate triggers the `componentWillUnmount` component lifecycle event.
+Flag to configure the calling of `props.onExportState` when Floodgate triggers the `componentWillUnmount` component lifecycle event.
 
-#### `exportState`       
+#### `onExportState`       
 
 *Arguments:* `{ currentIndex: number, renderedItems: any[], allItemsRendered: boolean }`
 
-Prop callback function that executes when Floodgate triggers the `componentWillUnmount` component lifecycle event. It provides a single object argument that represents a set of internal state properties that can be exported to a different component; this is best used on instances that will be toggled (un)mounted, such as in tabs or a single page application.
+Prop callback function that executes when Floodgate triggers the `componentWillUnmount` component lifecycle event, or when the [`exportState`](#exportState) is called from the render prop function. It provides a single object argument that represents a set of internal state properties that can be exported to a different component; this is best used on instances that will be toggled (un)mounted, such as in tabs or a single page application.
 
 `currentIndex` is a number representing the index of the last item passed through the queue to `state.renderedItems`.
 
@@ -255,7 +255,7 @@ Callback property that fires after the `reset` method is called. This is execute
 | `loadAll`      | Function    | n/a     | `{callback?: Function}`                   | Action: loads all `items`; `callback` prop in argument fires immediately after invocation|                                                                                           |
 | `loadNext`     | Function    | n/a     | `{silent?: boolean, callback?: Function}` | Action: loads the next set of items; `callback` prop in argument fires immediately after invocation, `silent` determinse if `onLoadNext` callback is fired after calling `loadNext`| |
 | `reset`        | Function    | n/a     | `{callback?: Function}`                   | Action: resets the state of the `Floodgate` instance to the initial state; `callback` prop in argument fires immediately after invocation|                                           |
-| `saveState`    | Function    | n/a     | `null`                                    | Action: calls the `exportState` prop callback|                                                                                                                                       |
+| `exportState`  | Function    | n/a     | `null`                                    | Action: calls the `onExportState` prop callback|                                                                                                                                     |
 #### `items`
 
 *Type:* `Array<any> = null`
@@ -296,15 +296,15 @@ The `callback` argument method will be called after `loadNext` has set the compo
 
 Resets Floodgate's state to the current instance's `data` and `initial` prop values.
 
-The `initial` argument property provides the ability to pass in a custom `initial` value to the next rendering after `reset` is called; this is most useful when writing a [controlled Floodgate component](#controlled-floodgate) and the `exportState` prop is used. For more information on why this is needed, see [pull request #42](https://github.com/geoffdavis92/react-floodgate/pull/42).
+The `initial` argument property provides the ability to pass in a custom `initial` value to the next rendering after `reset` is called; this is most useful when writing a [controlled Floodgate component](#controlled-floodgate) and the `onExportState` prop is used. For more information on why this is needed, see [pull request #42](https://github.com/geoffdavis92/react-floodgate/pull/42).
 
 The `callback` argument method will be called after `reset` has set the component's state; it will have access to this updated Floodgate `state`.
 
-#### `saveState`
+#### `exportState`
 
 *Arguments:* `n/a`
 
-Calls the `exportState` prop callback. Any logic to manipulate and/or save Floodgate's state to a parent component should happen in that prop; since the `exportState` arguments are not configurable, there are no arguments for `saveState`.
+Calls the `onExportState` prop callback. Any logic to manipulate and/or save Floodgate's state to a parent component should happen in that prop; since the `onExportState` arguments are not configurable, there are no arguments for `exportState`.
 
 ### Using `FloodgateContext`
 

--- a/__tests__/floodgate.test.js
+++ b/__tests__/floodgate.test.js
@@ -15,7 +15,7 @@ Enzyme.configure({ adapter: new Adapter() });
 // Wrapped instance for unMount
 class WrappedFloodgate extends React.Component {
   static defaultProps = {
-    floodgateSaveStateOnUnmount: true
+    floodgateExportStateOnUnmount: true
   };
   constructor() {
     super();
@@ -80,8 +80,8 @@ class WrappedFloodgate extends React.Component {
             data={this.state.savedState.data}
             initial={this.state.savedState.initial}
             increment={this.state.savedState.increment}
-            saveStateOnUnmount={this.props.floodgateSaveStateOnUnmount}
-            exportState={this.cacheFloodgateState}
+            exportStateOnUnmount={this.props.floodgateExportStateOnUnmount}
+            onExportState={this.cacheFloodgateState}
           >
             {({ items, loadNext, loadAll, reset, loadComplete }) => (
               <main>
@@ -127,11 +127,11 @@ class ControlledFloodgate extends React.Component {
       fetchActive: false,
       data: [0, 1, 2]
     };
-    this.saveState = this.saveState.bind(this);
+    this.exportState = this.exportState.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.addDataToState = this.addDataToState.bind(this);
   }
-  saveState(FloodgateState) {
+  exportState(FloodgateState) {
     this.setState(prevState => ({
       cachedFloodgateState: FloodgateState
     }));
@@ -492,11 +492,11 @@ describe("A. Floodgate", () => {
 
 describe("B. Wrapped Floodgate for saveState testing", () => {
   it("1. Should render a wrapped Floodgate instance", () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const wfgi = mount(<WrappedFloodgate floodgateExportStateOnUnmount />);
     expect(toJSON(wfgi)).toMatchSnapshot();
   });
   it("2. Should load 3 items, and save the currentIndex to the WrappedFloodgate state on cWU", () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const wfgi = mount(<WrappedFloodgate floodgateExportStateOnUnmount />);
     const fgi = wfgi.find(Floodgate).instance();
     const loadBtn = wfgi.find("button#load");
     const toggleBtn = wfgi.find("button#toggleFloodgate");
@@ -519,7 +519,7 @@ describe("B. Wrapped Floodgate for saveState testing", () => {
     });
   });
   it("2. Should load 3 items, click to load 3 more items, toggle Floodgate, and persist Floodgate state through mounting/re-mounting", () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const wfgi = mount(<WrappedFloodgate floodgateExportStateOnUnmount />);
     const getFgi = () => wfgi.find(Floodgate).instance();
     const loadBtn = wfgi.find("button#load");
     const toggleBtn = wfgi.find("button#toggleFloodgate");
@@ -548,7 +548,7 @@ describe("B. Wrapped Floodgate for saveState testing", () => {
     expect(getFgi().state.currentIndex).toBe(6);
   });
   it("3. Should load 3 items, toggle Floodgate, randomly splice data entries, then persist Floodgate index state through mounting/re-mounting", () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const wfgi = mount(<WrappedFloodgate floodgateExportStateOnUnmount />);
     const getFgi = () => wfgi.find(Floodgate).instance();
     const toggleBtn = wfgi.find("button#toggleFloodgate");
 
@@ -574,7 +574,7 @@ describe("B. Wrapped Floodgate for saveState testing", () => {
     );
   });
   it("4. Should load 3 items, click to load all items, toggle Floodgate, reset should update state based on newInitial argument prop", () => {
-    const wfgi = mount(<WrappedFloodgate floodgateSaveStateOnUnmount />);
+    const wfgi = mount(<WrappedFloodgate floodgateExportStateOnUnmount />);
     const getFgi = () => wfgi.find(Floodgate).instance();
     const getResetBtn = () => wfgi.find("button#reset");
     const loadAllBtn = wfgi.find("button#loadall");
@@ -712,7 +712,7 @@ describe("D. Context-Wrapped Floodgate", () => {
       loadAll: fgi.instance().loadAll,
       loadNext: fgi.instance().loadNext,
       reset: fgi.instance().reset,
-      saveState: fgi.instance().saveState
+      exportState: fgi.instance().exportState
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     data: PropTypes.array.isRequired,
     initial: PropTypes.number,
     increment: PropTypes.number,
-    saveStateOnUnmount: PropTypes.bool,
+    exportStateOnUnmount: PropTypes.bool,
     exportState: PropTypes.func,
     onLoadNext: PropTypes.func,
     onLoadComplete: PropTypes.func,
@@ -29,7 +29,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
   static defaultProps = {
     initial: 5,
     increment: 5,
-    saveStateOnUnmount: true
+    exportStateOnUnmount: true
   };
 
   // methods
@@ -53,7 +53,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     this.loadAll = this.loadAll.bind(this);
     this.loadNext = this.loadNext.bind(this);
     this.reset = this.reset.bind(this);
-    this.saveState = this.saveState.bind(this);
+    this.exportState = this.exportState.bind(this);
     this[initGeneratorSymbol](
       this.props.data,
       this.props.increment,
@@ -82,8 +82,8 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     }
   }
   componentWillUnmount(): void {
-    // Prevent unwanted cacheing by setting saveStateOnUnmount to false
-    this.props.saveStateOnUnmount && this.saveState();
+    // Prevent unwanted cacheing by setting exportStateOnUnmount to false
+    this.props.exportStateOnUnmount && this.exportState();
   }
   reset({
     initial,
@@ -180,17 +180,17 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
       );
     }
   }
-  saveState() {
+  exportState() {
     const { renderedItems, currentIndex, allItemsRendered } = this.state;
-    this.props.exportState &&
-      this.props.exportState({
+    this.props.onExportState &&
+      this.props.onExportState({
         currentIndex,
         renderedItems,
         allItemsRendered
       });
   }
   render() {
-    const { loadAll, loadNext, reset, saveState } = this;
+    const { loadAll, loadNext, reset, exportState } = this;
     const { renderedItems, allItemsRendered } = this.state;
     const floodgateInternals = {
       items: renderedItems,
@@ -198,7 +198,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
       loadAll,
       loadNext,
       reset,
-      saveState
+      exportState
     };
     return (
       <FloodgateContext.Provider value={floodgateInternals}>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,13 +18,13 @@ type FloodgateProps = {
     loadAll: Function,
     loadNext: Function,
     reset: Function,
-    saveState: Function
+    exportState: Function
   }) => JSX.Element,
   data: any[],
   increment: number,
   initial: number,
-  saveStateOnUnmount?: boolean,
-  exportState?: Function,
+  exportStateOnUnmount?: boolean,
+  onExportState?: Function,
   onLoadNext?: Function,
   onLoadComplete?: Function,
   onReset?: Function


### PR DESCRIPTION
### What:
<!-- what changes are being made? -->
Rename instances of Floodgate's `saveState` method with `exportState` and update Floodgate's `exportState` prop to be `onExportState`.

Additional naming convention changes revolve around renaming anything with the following pattern `.*[sS]aveState` to the `.*[eE]xportState` pattern.

### Why:
<!-- why are these changes necessary? -->
`saveState` doesn't actually save anything, but exposes state to some controlling component, so the "save" prefix makes no sense to keep in place.

These changes unify the API around the "exporting" of state to outside the Floodgate instance, and keeps the previous `exportState` callback prop in line with other callback props by adopting the `on<ActionName>` syntax.

### How:
<!-- how are these changes implemented? -->

Renamed method/prop names, type definitions.

### Reference: <!-- Link any issues this PR may close or pertain to; eg #24, #33, etc -->

Closes #43 
