### PR TITLE
Bump react, react-dom versions to pin to 16.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"jest": "^21.2.1",
 		"lorem-ipsum": "^1.0.4",
 		"prettier": "^1.7.4",
-		"react-dom": "^16.3.0",
+		"react-dom": "^16.8.0",
 		"react-test-renderer": "^16.0.0",
 		"regenerator-runtime": "^0.12.1",
 		"rollup": "^0.50.0",
@@ -64,7 +64,7 @@
 	"dependencies": {
 		"@types/prop-types": "^15.5.5",
 		"prop-types": "^15.6.2",
-		"react": "^16.3.0"
+		"react": "^16.8.0"
 	},
 	"scripts": {
 		"build": "NODE_ENV=rollup ./node_modules/.bin/rollup -c --bundle && yarn test",


### PR DESCRIPTION
### What:
<!-- what changes are being made? -->

Bump React, ReactDOM dependency versions to latest minor version.

### Why:
<!-- why are these changes necessary? -->

Aligns Floodgate with up-to-date React versions, allows for developing against React API features implemented since 16.3.

### How:
<!-- how are these changes implemented? -->

Updated `package.json` versions.

### Reference: <!-- Link any issues this PR may close or pertain to; eg #24, #33, etc -->

Closes #44 