### PR TITLE
Remove "data" Class Property

### DIFF
--- a/__tests__/floodgate.test.js
+++ b/__tests__/floodgate.test.js
@@ -856,7 +856,15 @@ describe("D. Context-Wrapped Floodgate", () => {
     );
 
     getAllButton().simulate("click");
-    expect(getFG().data).toMatchObject(getFG().props.data);
+    expect(getFG().state.items).toMatchObject(getFG().props.data);
     expect(getStringList().children().length).toBe(getFG().props.data.length);
+    expect(getStringList().children().length).toBe(
+      getFG().state.renderedItems.length
+    );
+
+    getResetButton().simulate("click");
+
+    expect(getFG().props.initial).toBe(getFG().state.renderedItems.length);
+    expect(getFG().props.initial).toBe(getStringList().children().length);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-floodgate",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Configurable and flexible \"load more\" component for React",
 	"keywords": [
 		"react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,6 @@ const FloodgateContext = React.createContext({});
 
 class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
   // types
-  data: Array<any>;
   queue: Generator | null;
   state: FloodgateState;
 
@@ -37,9 +36,8 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     super(props);
     const { data, increment, initial } = props;
     this.queue = null;
-    this.data = data;
     this.state = {
-      items: this.data,
+      items: data,
       renderedItems: [],
       currentIndex: 0,
       allItemsRendered: false,
@@ -82,9 +80,6 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
         items,
         allItemsRendered: items.length === prevState.renderedItems.length
       }));
-
-      // Update data property
-      this.data = data;
     }
   }
   componentWillUnmount(): void {
@@ -96,7 +91,7 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
     callback
   }: { initial?: number, callback?: Function } = {}): void {
     this[initGeneratorSymbol](
-      this.data,
+      this.props.data,
       this.props.increment,
       typeof initial !== "undefined" ? initial : this.props.initial
     );
@@ -128,8 +123,8 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
       ? this.setState(
           prevState => {
             return {
-              renderedItems: this.data,
-              currentIndex: this.data.length,
+              renderedItems: this.props.data,
+              currentIndex: this.props.data.length,
               allItemsRendered: true
             };
           },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,16 +69,22 @@ class Floodgate extends React.Component<FloodgateProps, FloodgateState> {
   componentDidUpdate(prevProps, prevState): void {
     const { data, increment } = this.props;
     if (this.props !== prevProps) {
+      // Initialize new generator
       this[initGeneratorSymbol](
         data.slice(prevState.currentIndex, data.length),
         increment,
         increment
       );
+
+      // Set new state
       const items = data;
       this.setState(() => ({
         items,
         allItemsRendered: items.length === prevState.renderedItems.length
       }));
+
+      // Update data property
+      this.data = data;
     }
   }
   componentWillUnmount(): void {


### PR DESCRIPTION
### What:

These changes remove the `Floodgate.data` class property and update tests that access this property.

### Why:

This property was unnecessary, and created additional surface area by which bugs could appear. `Floodgate.data` should always be the same as `Floodgate.props.data` so there was no need to have this additional pass-through property.

<!-- 
These changes update the `componentDidUpdate` lifecycle method to update the `Floodgate.data` class property when `Floodgate.props` updates.

When a `Floodgate` instance loads data from a parent component via props, it currently only updates the `state` class property and initializes a new generator to use for the queue. When a parent loads data asynchronously that is then passed to Floodgate, the `Floodgate.data` class property is only assigned the initial data that is passed from the parent, and does not update to reflect the updated props value. -->

### How:

Replace of `this.data` instances with `this.props.data`; remove any typing for `Floodgate.data`.

### Reference: <!-- Link any issues this PR may close or pertain to; eg #24, #33, etc -->

Closes #47